### PR TITLE
change: all client-facing "Provisions" text to "Requirements"

### DIFF
--- a/src/components/dashboard/CountriesMap.tsx
+++ b/src/components/dashboard/CountriesMap.tsx
@@ -60,7 +60,7 @@ export const CountriesMap = ({ data, isLoading }: CountriesMapProps) => {
       <CardHeader className="pb-2">
         <CardTitle className="mb-4">Policy Coverage</CardTitle>
         <div className="text-sm text-muted-foreground space-y-1">
-          <p>Your plan covers {totalPolicies} policies and {totalProvisions} provisions across {totalCountries} countries.</p>
+          <p>Your plan covers {totalPolicies} policies and {totalProvisions} requirements across {totalCountries} countries.</p>
           <p>Please select each country below to see its policy coverage.</p>
         </div>
       </CardHeader>
@@ -109,7 +109,7 @@ export const CountriesMap = ({ data, isLoading }: CountriesMapProps) => {
                             tooltip.innerHTML = `
                               <p class="font-semibold">${geo.properties.NAME}</p>
                               <p>Policies: ${countryData?.count || 0}</p>
-                              <p>Provisions: ${provisionsCount}</p>
+                              <p>Requirements: ${provisionsCount}</p>
                             `;
                             tooltip.style.position = 'fixed';
                             tooltip.style.left = `${event.clientX + 10}px`;

--- a/src/components/dashboard/RecentProvisionsList.tsx
+++ b/src/components/dashboard/RecentProvisionsList.tsx
@@ -1,4 +1,3 @@
-
 import { Activity } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -31,7 +30,7 @@ export const RecentProvisionsList = ({
     <Card className="col-span-1 flex flex-col h-full">
       <CardHeader>
         <div className="flex justify-between items-center">
-          <CardTitle>New Provisions</CardTitle>
+          <CardTitle>New Requirements</CardTitle>
           <Select value={timeFilter} onValueChange={onTimeFilterChange}>
             <SelectTrigger className="w-[140px]">
               <SelectValue placeholder="Select time range" />
@@ -50,7 +49,7 @@ export const RecentProvisionsList = ({
           ) : !provisions?.length ? (
             <Alert>
               <AlertDescription>
-                There are no new provisions.
+                There are no new requirements.
               </AlertDescription>
             </Alert>
           ) : (

--- a/src/components/dashboard/UpdatesList.tsx
+++ b/src/components/dashboard/UpdatesList.tsx
@@ -1,4 +1,3 @@
-
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { 
   Select, 
@@ -56,7 +55,7 @@ export const UpdatesList = ({
                 size="sm"
                 onClick={() => onViewModeChange('provisions')}
               >
-                Provisions
+                Requirements
               </Button>
               <Button
                 variant={viewMode === 'policies' ? 'default' : 'outline'}

--- a/src/components/search/PolicyDetailsDialog.tsx
+++ b/src/components/search/PolicyDetailsDialog.tsx
@@ -105,7 +105,7 @@ export const PolicyDetailsDialog = ({ policy, open, onOpenChange }: PolicyDetail
                   className="text-muted-foreground data-[state=active]:bg-background data-[state=active]:text-foreground rounded-md h-10"
                 >
                   <div className="flex items-center gap-2">
-                    Provisions
+                    Requirements
                     <span className="inline-flex items-center justify-center h-5 w-5 rounded-full bg-primary">
                       <span className="text-xs font-medium text-white">
                         {provisions.length}
@@ -174,7 +174,7 @@ export const PolicyDetailsDialog = ({ policy, open, onOpenChange }: PolicyDetail
                 <TabsContent value="provisions" className="h-full absolute inset-0">
                   <TabContentWrapper>
                     <div className="h-full">
-                      <h2 className="text-xl font-semibold mb-4">Provisions</h2>
+                      <h2 className="text-xl font-semibold mb-4">Requirements</h2>
                       {provisions.length > 0 ? (
                         <div className="space-y-4">
                           {provisions.map((provision) => (
@@ -189,7 +189,7 @@ export const PolicyDetailsDialog = ({ policy, open, onOpenChange }: PolicyDetail
                           <div className="bg-muted/50 rounded-lg p-8 text-center">
                             <ListChecks className="h-8 w-8 text-muted-foreground mx-auto mb-2" />
                             <p className="text-sm text-muted-foreground">
-                              There are no provisions associated with this policy.
+                              There are no requirements associated with this policy.
                             </p>
                           </div>
                         </div>

--- a/src/components/search/ProvisionDetailsDialog.tsx
+++ b/src/components/search/ProvisionDetailsDialog.tsx
@@ -43,7 +43,7 @@ export const ProvisionDetailsDialog = ({ provision, open, onOpenChange }: Provis
                 </div>
               )}
               <DialogTitle className="text-xl font-semibold">
-                {provision.requirement || "Untitled Provision"}
+                {provision.requirement || "Untitled Requirement"}
               </DialogTitle>
             </div>
             

--- a/src/components/search/ProvisionsTable.tsx
+++ b/src/components/search/ProvisionsTable.tsx
@@ -1,4 +1,3 @@
-
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
@@ -143,7 +142,7 @@ export const ProvisionsTable = ({ filters, searchQuery }: ProvisionsTableProps) 
         <Table>
           <TableHeader className="sticky top-0 bg-white z-10">
             <TableRow>
-              <SortableHeader field="requirement">Provision</SortableHeader>
+              <SortableHeader field="requirement">Requirement</SortableHeader>
               <SortableHeader field="country">Country</SortableHeader>
               <SortableHeader field="topic">Topic</SortableHeader>
               <SortableHeader field="year_of_enforcement">Year of Enforcement</SortableHeader>
@@ -152,7 +151,7 @@ export const ProvisionsTable = ({ filters, searchQuery }: ProvisionsTableProps) 
           <TableBody>
             <TableRow>
               <TableCell colSpan={4} className="text-center h-24 text-muted-foreground">
-                Loading provisions...
+                Loading requirements...
               </TableCell>
             </TableRow>
           </TableBody>
@@ -167,7 +166,7 @@ export const ProvisionsTable = ({ filters, searchQuery }: ProvisionsTableProps) 
         <Table>
           <TableHeader className="sticky top-0 bg-white z-10">
             <TableRow>
-              <SortableHeader field="requirement">Provision</SortableHeader>
+              <SortableHeader field="requirement">Requirement</SortableHeader>
               <SortableHeader field="country">Country</SortableHeader>
               <SortableHeader field="topic">Topic</SortableHeader>
               <SortableHeader field="year_of_enforcement">Year of Enforcement</SortableHeader>
@@ -176,7 +175,7 @@ export const ProvisionsTable = ({ filters, searchQuery }: ProvisionsTableProps) 
           <TableBody>
             <TableRow>
               <TableCell colSpan={4} className="text-center h-24 text-muted-foreground text-red-600">
-                Error loading provisions: {error.message}
+                Error loading requirements: {error.message}
               </TableCell>
             </TableRow>
           </TableBody>
@@ -192,7 +191,7 @@ export const ProvisionsTable = ({ filters, searchQuery }: ProvisionsTableProps) 
         <Table>
           <TableHeader className="sticky top-0 bg-white z-10">
             <TableRow>
-              <SortableHeader field="requirement">Provision</SortableHeader>
+              <SortableHeader field="requirement">Requirement</SortableHeader>
               <SortableHeader field="country">Country</SortableHeader>
               <SortableHeader field="topic">Topic</SortableHeader>
               <SortableHeader field="year_of_enforcement">Year of Enforcement</SortableHeader>
@@ -223,7 +222,7 @@ export const ProvisionsTable = ({ filters, searchQuery }: ProvisionsTableProps) 
             ) : (
               <TableRow>
                 <TableCell colSpan={4} className="text-center h-24 text-muted-foreground">
-                  No provisions found
+                  No requirements found
                 </TableCell>
               </TableRow>
             )}

--- a/src/components/search/SearchHeader.tsx
+++ b/src/components/search/SearchHeader.tsx
@@ -1,4 +1,3 @@
-
 import { Search as SearchIcon, FileText, ScrollText } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -35,7 +34,7 @@ export const SearchHeader = ({
             className="gap-2"
           >
             <ScrollText className="h-4 w-4" />
-            Provisions
+            Requirements
           </Button>
           <Button
             variant={viewMode === 'policies' ? 'default' : 'outline'}

--- a/src/components/settings/SearchSettings.tsx
+++ b/src/components/settings/SearchSettings.tsx
@@ -1,4 +1,3 @@
-
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
@@ -70,7 +69,7 @@ export function SearchSettings() {
                         <RadioGroupItem value="provisions" />
                       </FormControl>
                       <FormLabel className="font-normal">
-                        Provisions
+                        Requirements
                       </FormLabel>
                     </FormItem>
                   </RadioGroup>


### PR DESCRIPTION
Context: 
"Provisions" can be confusing to clients. We changed this to "Requirements" instead which is more self-explanatory.

Only client-facing UI was changed, code variable names remain unchanged.