### PR TITLE
Fix/li 110: Fixed stale state bug and unresponsive clicking on filter buttons

### DIFF
--- a/src/components/search/FilterSection.tsx
+++ b/src/components/search/FilterSection.tsx
@@ -1,4 +1,3 @@
-
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { PolicyFiltersState, ProvisionFiltersState } from "@/types/search";
@@ -124,9 +123,9 @@ export const FilterSection = ({
       </div>
       <div className="grid grid-cols-2 gap-3 max-h-[60vh] overflow-y-auto pr-2">
         {options.map((option) => (
-          <div
+          <label
             key={option}
-            onClick={() => handleFilterChange(filterType, option, !selectedValues.includes(option))}
+            htmlFor={`${filterType}-${option}`}
             className={`
               p-3 rounded-lg border cursor-pointer transition-all
               ${selectedValues.includes(option)
@@ -139,18 +138,15 @@ export const FilterSection = ({
               <Checkbox
                 id={`${filterType}-${option}`}
                 checked={selectedValues.includes(option)}
-                onCheckedChange={(checked) => 
+                onCheckedChange={(checked) =>
                   handleFilterChange(filterType, option, checked === true)
                 }
               />
-              <label
-                htmlFor={`${filterType}-${option}`}
-                className="text-sm leading-none flex-1 cursor-pointer"
-              >
+              <span className="text-sm leading-none flex-1">
                 {option}
-              </label>
+              </span>
             </div>
-          </div>
+          </label>
         ))}
       </div>
     </div>

--- a/src/components/search/FilterTabs.tsx
+++ b/src/components/search/FilterTabs.tsx
@@ -69,7 +69,8 @@ export const FilterTabs = ({
                     <TabsTrigger 
                       key={tab.value} 
                       value={tab.value}
-                      className="relative h-9 data-[state=active]:bg-white data-[state=active]:shadow-none rounded-md whitespace-nowrap px-3"
+                      className="relative h-9 data-[state=active]:border-[1px] 
+                      data-[state=active]:border-primary rounded-md whitespace-nowrap px-3"
                     >
                       <span className="text-xs sm:text-sm truncate">
                         {tab.label}

--- a/src/hooks/useSearchFilters.ts
+++ b/src/hooks/useSearchFilters.ts
@@ -21,13 +21,18 @@ export const useSearchFilters = (viewMode: ViewMode) => {
   const filters = viewMode === 'policies' ? policyFilters : provisionFilters;
   const setFilters = viewMode === 'policies' ? setPolicyFilters : setProvisionFilters;
 
-  const handleFilterChange = (filterType: keyof (PolicyFiltersState & ProvisionFiltersState), value: string, checked: boolean) => {
-    setFilters(prev => ({
-      ...prev,
-      [filterType]: checked
-        ? [...(prev as any)[filterType], value]
-        : (prev as any)[filterType].filter((item: string) => item !== value)
-    }));
+  const handleFilterChange = (filterType: keyof (PolicyFiltersState & ProvisionFiltersState), value: string) => {
+    setFilters(prev => {
+      const currentFilterValues = (prev as any)[filterType] as string[];
+      const valueExists = currentFilterValues.includes(value);
+
+      return {
+        ...prev,
+        [filterType]: valueExists
+          ? currentFilterValues.filter((item: string) => item !== value)
+          : [...currentFilterValues, value]
+      };
+    });
   };
 
   const handleSelectAll = (filterType: keyof (PolicyFiltersState & ProvisionFiltersState), options: string[]) => {


### PR DESCRIPTION
- Refactored the filter state update logic so that all add/remove operations are now calculated inside the state setter, ensuring up-to-date and reliable state transitions.

- Removed redundant event handlers in the filter UI, preventing the filter state from being updated twice on a single user action. (self-cancelling)

- Prettified: Added border for selected filter