### PR TITLE
fix: flex display difference between mobile and desktop

### DIFF
--- a/src/components/search/SearchHeader.tsx
+++ b/src/components/search/SearchHeader.tsx
@@ -2,6 +2,7 @@ import { Search as SearchIcon, FileText, ScrollText } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { ViewMode } from "@/types/search";
+import { useIsMobile } from "@/hooks/use-mobile";
 
 interface SearchHeaderProps {
   searchQuery: string;
@@ -20,10 +21,12 @@ export const SearchHeader = ({
   activeFiltersCount,
   setActiveFilterTab,
 }: SearchHeaderProps) => {
+  const isMobile = useIsMobile();
+
   return (
     <div className="mb-8">
-      <h1 className="text-3xl font-bold text-center md:text-left py-3">Search</h1>
-      <div className="flex items-center gap-4 mb-4">
+      <div className={`flex ${isMobile ? 'flex-col' : ''} items-center gap-4 mb-4`}>
+        <h1 className="text-3xl font-bold text-center md:text-left py-3">Search</h1>
         <div className="flex gap-2">
           <Button
             variant={viewMode === 'provisions' ? 'default' : 'outline'}

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -116,7 +116,7 @@ const Search = () => {
             activeFiltersCount={activeFiltersCount}
             setActiveFilterTab={setActiveFilterTab}
           />
-          <div className="flex flex-col sm:flex-row items-start sm:items-center gap-4">
+          <div className="flex items-start sm:items-center gap-4">
             <SearchInput searchQuery={searchQuery} setSearchQuery={setSearchQuery} />
             <FilterTabs
               viewMode={viewMode}


### PR DESCRIPTION
### Description 

 
After my fix for mobile display, the `Requirements-Policies` selector buttons appear below the `Search` title instead of next to it (as it should and as it was).

Fixed it by choosing flex-col in mobile and flex-row in desktop.
 

### Related Issue 
 

N/A 


--- 


### Checklist 


*Please check each item that applies to this PR.* 
 

- [ ]  Code is reviewed for quality and follows coding standards. 

- [ ]  Unit tests are added/updated to cover the changes. 

- [ ]  All tests are passing, and the build is successful. 

- [ ]  Code is well-documented (if applicable). 

- [ ]  Accessibility considerations are addressed. 

- [ ]  Browser compatibility is maintained (if required). 

- [ ]  Cross-browser testing is performed (list browsers/devices). 

- [ ]  UI/UX design is reviewed and approved (if relevant). 

- [ ]  Performance optimizations are considered (if relevant). 

- [ ]  Security concerns are addressed (if relevant). 

- [ ]  Dependencies are updated (if needed). 
