### PR TITLE
fix: building_status wrong provision data bug

### DIFF
--- a/src/components/search/components/tabs/OverviewTab.tsx
+++ b/src/components/search/components/tabs/OverviewTab.tsx
@@ -2,6 +2,7 @@ interface Provision {
   requirement: string;
   subject_to_obligation?: string;
   asset_class?: string;
+  building_status?: string;
 }
 
 export const OverviewTab = ({ provision }: { provision: Provision | null }) => {
@@ -21,7 +22,7 @@ export const OverviewTab = ({ provision }: { provision: Provision | null }) => {
             <span className="text-sm font-medium w-32">Building Status</span>
             <span className="text-sm text-muted-foreground">
               {" "}
-              {provision.subject_to_obligation ?? "N/A"}
+              {provision.building_status ?? "N/A"}
             </span>
           </div>
 


### PR DESCRIPTION
### Description 

 
Frontend was using the same data for building status and `subject to obligation` for no reason. 

Simple fix to just use the correct building status.
 

### Related Issue 
 

N/A 


--- 


### Checklist 


*Please check each item that applies to this PR.* 
 

- [ ]  Code is reviewed for quality and follows coding standards. 

- [ ]  Unit tests are added/updated to cover the changes. 

- [ ]  All tests are passing, and the build is successful. 

- [ ]  Code is well-documented (if applicable). 

- [ ]  Accessibility considerations are addressed. 

- [ ]  Browser compatibility is maintained (if required). 

- [ ]  Cross-browser testing is performed (list browsers/devices). 

- [ ]  UI/UX design is reviewed and approved (if relevant). 

- [ ]  Performance optimizations are considered (if relevant). 

- [ ]  Security concerns are addressed (if relevant). 

- [ ]  Dependencies are updated (if needed). 
