### PR TITLE
fix: give height to table so that sticky works

### DIFF
--- a/src/components/search/PoliciesTable.tsx
+++ b/src/components/search/PoliciesTable.tsx
@@ -102,8 +102,7 @@ export const PoliciesTable = ({ policies }: PoliciesTableProps) => {
 
   return (
     <>
-      <div className="overflow-x-auto">
-        <Table>
+      <Table>
           <TableHeader className="sticky top-0 bg-white z-10">
             <TableRow>
               <SortableHeader field="title">Policy</SortableHeader>
@@ -156,8 +155,7 @@ export const PoliciesTable = ({ policies }: PoliciesTableProps) => {
               </TableRow>
             ))}
           </TableBody>
-        </Table>
-      </div>
+      </Table>
 
       <PolicyDetailsDialog 
         policy={selectedPolicy}

--- a/src/components/search/ProvisionsTable.tsx
+++ b/src/components/search/ProvisionsTable.tsx
@@ -184,8 +184,6 @@ export const ProvisionsTable = ({ filters, searchQuery }: ProvisionsTableProps) 
 
   return (
     <>
-      <div>
-
         <Table>
           <TableHeader className="sticky top-0 bg-white z-10">
             <TableRow>
@@ -225,8 +223,7 @@ export const ProvisionsTable = ({ filters, searchQuery }: ProvisionsTableProps) 
               </TableRow>
             )}
           </TableBody>
-        </Table>
-      </div>
+      </Table>
 
       <ProvisionDetailsDialog
         provision={selectedProvision}

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -6,7 +6,7 @@ const Table = React.forwardRef<
   HTMLTableElement,
   React.HTMLAttributes<HTMLTableElement>
 >(({ className, ...props }, ref) => (
-  <div className="relative w-full overflow-auto">
+  <div className="relative w-full h-full overflow-auto">
     <table
       ref={ref}
       className={cn("w-full caption-bottom text-sm", className)}


### PR DESCRIPTION
### Description 

 div enclosing table had no height, sticky was not working. Gave height to it, sticky works


### Related Issue 
 

N/A 


--- 


### Checklist 


*Please check each item that applies to this PR.* 
 

- [ ]  Code is reviewed for quality and follows coding standards. 

- [ ]  Unit tests are added/updated to cover the changes. 

- [ ]  All tests are passing, and the build is successful. 

- [ ]  Code is well-documented (if applicable). 

- [ ]  Accessibility considerations are addressed. 

- [ ]  Browser compatibility is maintained (if required). 

- [ ]  Cross-browser testing is performed (list browsers/devices). 

- [ ]  UI/UX design is reviewed and approved (if relevant). 

- [ ]  Performance optimizations are considered (if relevant). 

- [ ]  Security concerns are addressed (if relevant). 

- [ ]  Dependencies are updated (if needed). 
